### PR TITLE
Add register and login endpoints and frontend auth forms

### DIFF
--- a/backend/src/auth/models.py
+++ b/backend/src/auth/models.py
@@ -1,0 +1,11 @@
+# backend/src/auth/models.py
+from sqlalchemy import Column, Integer, String, Boolean
+from ..db import Base
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    role = Column(String, default="user")
+    is_active = Column(Boolean, default=True)

--- a/backend/src/auth/routes.py
+++ b/backend/src/auth/routes.py
@@ -1,0 +1,43 @@
+# backend/src/auth/routes.py
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, EmailStr
+from sqlalchemy.orm import Session
+from ..db import SessionLocal
+from .models import User
+from .utils import hash_password, verify_password, create_access_token
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+class RegisterIn(BaseModel):
+    email: EmailStr
+    password: str
+    role: str = "user"
+
+class LoginIn(BaseModel):
+    email: EmailStr
+    password: str
+
+@router.post("/register")
+def register(payload: RegisterIn, db: Session = Depends(get_db)):
+    if db.query(User).filter(User.email == payload.email).first():
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user = User(email=payload.email, hashed_password=hash_password(payload.password), role=payload.role)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return {"msg": "registered", "email": user.email, "role": user.role}
+
+@router.post("/login")
+def login(payload: LoginIn, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == payload.email).first()
+    if not user or not verify_password(payload.password, user.hashed_password):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_access_token(subject=str(user.id), data={"role": user.role, "email": user.email})
+    return {"access_token": token, "token_type": "bearer"}

--- a/backend/src/auth/utils.py
+++ b/backend/src/auth/utils.py
@@ -1,0 +1,23 @@
+# backend/src/auth/utils.py
+import os, time
+from passlib.context import CryptContext
+from jose import jwt
+
+pwd_ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+SECRET_KEY = os.environ.get("JWT_SECRET", "super-secret-demo-key")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60 * 24  # 24h
+
+def hash_password(password: str) -> str:
+    return pwd_ctx.hash(password)
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_ctx.verify(plain, hashed)
+
+def create_access_token(subject: str, data: dict = None, expires_in: int = ACCESS_TOKEN_EXPIRE_SECONDS):
+    payload = {"sub": subject}
+    if data:
+        payload.update(data)
+    payload.update({"exp": int(time.time()) + int(expires_in)})
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,0 +1,21 @@
+# backend/src/main.py
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from .db import engine, Base
+from .auth import routes as auth_routes
+# import models so tables are registered
+from .auth import models as auth_models  # noqa
+
+app = FastAPI(title="Backend API")
+
+# Allow frontend origin
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth_routes.router)
+Base.metadata.create_all(bind=engine)

--- a/frontend/frontend/postcss.config.js
+++ b/frontend/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/frontend/src/App.jsx
+++ b/frontend/frontend/src/App.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+function App() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+      <h1 className="text-3xl font-bold mb-6">Welcome to Auth System</h1>
+      <div className="space-x-4">
+        <Link
+          to="/login"
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Login
+        </Link>
+        <Link
+          to="/signup"
+          className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+        >
+          Signup
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/frontend/src/index.css
+++ b/frontend/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/frontend/src/main.jsx
+++ b/frontend/frontend/src/main.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import App from "./App";
+import Login from "./pages/auth/Login";
+import Signup from "./pages/auth/Signup";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/frontend/src/pages/auth/Login.jsx
+++ b/frontend/frontend/src/pages/auth/Login.jsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const nav = useNavigate();
+
+  const handleLogin = async (e) => {
+    e.preventDefault();
+    const res = await fetch("http://127.0.0.1:8000/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    const data = await res.json();
+    if (res.ok && data.access_token) {
+      localStorage.setItem("access_token", data.access_token);
+      nav("/dashboard");
+    } else if (data.msg === "otp_sent") {
+      nav("/verify-otp", { state: { email } });
+    } else {
+      alert(data.detail || "Login failed");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+      <form onSubmit={handleLogin} className="bg-white shadow-lg rounded-lg p-6 w-80">
+        <h2 className="text-2xl font-semibold mb-4 text-center">Login</h2>
+        <input
+          type="email"
+          placeholder="Email"
+          className="border w-full p-2 mb-3 rounded"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="border w-full p-2 mb-3 rounded"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-600 text-white w-full py-2 rounded hover:bg-blue-700">Login</button>
+        <a href="/signup" className="block text-center text-sm mt-3 text-blue-600 underline">
+          Don't have an account? Sign up
+        </a>
+      </form>
+    </div>
+  );
+}

--- a/frontend/frontend/src/pages/auth/Signup.jsx
+++ b/frontend/frontend/src/pages/auth/Signup.jsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function Signup() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [role, setRole] = useState("user");
+  const nav = useNavigate();
+
+  const handleSignup = async (e) => {
+    e.preventDefault();
+    const res = await fetch("http://127.0.0.1:8000/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, role }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      alert("Registration successful!");
+      nav("/login");
+    } else {
+      alert(data.detail || "Signup failed");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+      <form onSubmit={handleSignup} className="bg-white shadow-lg rounded-lg p-6 w-80">
+        <h2 className="text-2xl font-semibold mb-4 text-center">Sign Up</h2>
+        <input
+          type="email"
+          placeholder="Email"
+          className="border w-full p-2 mb-3 rounded"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="border w-full p-2 mb-3 rounded"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <select
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+          className="border w-full p-2 mb-3 rounded"
+        >
+          <option value="user">User</option>
+          <option value="officer">Officer</option>
+          <option value="admin">Admin</option>
+        </select>
+        <button className="bg-green-600 text-white w-full py-2 rounded hover:bg-green-700">
+          Sign Up
+        </button>
+        <a href="/login" className="block text-center text-sm mt-3 text-blue-600 underline">
+          Already have an account? Login
+        </a>
+      </form>
+    </div>
+  );
+}

--- a/frontend/frontend/tailwind.config.js
+++ b/frontend/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tests/test_auth_forms.py
+++ b/tests/test_auth_forms.py
@@ -1,0 +1,16 @@
+# tests/test_auth_forms.py
+import time, os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from fastapi.testclient import TestClient
+from backend.src.main import app
+
+client = TestClient(app)
+
+def test_register_and_login_returns_token():
+    email = f"qa{int(time.time())}@example.com"
+    password = "TestPass123!"
+    r = client.post("/auth/register", json={"email": email, "password": password, "role": "user"})
+    assert r.status_code == 200
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    assert "access_token" in r.json()


### PR DESCRIPTION
Implements Design Login/Signup Forms for All User Types.

- Adds /auth/register and /auth/login endpoints that issue JWT tokens.
- Adds Signup and Login pages styled with Tailwind (Vite + React).
- Includes tests/test_auth_forms.py to verify backend register/login workflow.
- Adds Tailwind + PostCSS config for UI styling.

Closes #<2>
