### PR TITLE
Refactor User.role to RoleEnum and default registration to 'customer'

### DIFF
--- a/backend/src/auth/models.py
+++ b/backend/src/auth/models.py
@@ -1,15 +1,25 @@
 # backend/src/auth/models.py
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from enum import Enum
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Enum as SAEnum
+from sqlalchemy.orm import declarative_base
 from ..db import Base
 from datetime import datetime
+
+class RoleEnum(str, Enum):
+    CUSTOMER = "customer"
+    ANALYST = "analyst"
+    REGULATOR = "regulator"
+    ADMIN = "admin"
 
 class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
-    email = Column(String, unique=True, index=True, nullable=False)
+    email = Column(String, unique=True, nullable=False)
     hashed_password = Column(String, nullable=False)
-    role = Column(String, default="user")
+    
+    role = Column(SAEnum(RoleEnum, name="role_enum"), nullable=False, default=RoleEnum.CUSTOMER)
+
     is_active = Column(Boolean, default=True)
 
     # OTP (for login 2-step)

--- a/backend/src/auth/routes.py
+++ b/backend/src/auth/routes.py
@@ -1,13 +1,14 @@
 # backend/src/auth/routes.py
 import time
 import random
+from typing import Literal
 from datetime import datetime, timedelta
 from ..auth.utils import generate_verification_token, verify_token
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 from ..db import SessionLocal
-from .models import User
+from .models import User, RoleEnum
 from .utils import (
     hash_password,
     verify_password,
@@ -29,7 +30,6 @@ def get_db():
 class RegisterIn(BaseModel):
     email: EmailStr
     password: str
-    role: str = "user"
 
 class LoginIn(BaseModel):
     email: EmailStr
@@ -48,6 +48,10 @@ class RequestVerifyIn(BaseModel):
 class VerifyEmailIn(BaseModel):
     token: str
 
+class AssignRoleIn(BaseModel):
+    user_id: int
+    role: RoleEnum 
+
 # ---------- Endpoints ----------
 @router.post("/register")
 def register(payload: RegisterIn, db: Session = Depends(get_db)):
@@ -56,7 +60,7 @@ def register(payload: RegisterIn, db: Session = Depends(get_db)):
     user = User(
         email=payload.email,
         hashed_password=hash_password(payload.password),
-        role=payload.role,
+        role=RoleEnum.CUSTOMER,
     )
     db.add(user)
     db.commit()
@@ -122,3 +126,16 @@ def verify_email(payload: VerifyEmailIn, db: Session = Depends(get_db)):
     db.add(user)
     db.commit()
     return {"msg": "Email verified successfully", "email": user.email, "is_verified": user.is_verified}
+
+@router.post("/admin/assign-role")
+def assign_role(payload: AssignRoleIn, db: Session = Depends(get_db)):
+    # TODO: In next RBAC issue, protect this route with require_roles([RoleEnum.ADMIN])
+    user = db.get(User, payload.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    user.role = payload.role
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return {"msg": "role-assigned", "user_id": user.id, "role": user.role}

--- a/frontend/frontend/src/pages/auth/Signup.jsx
+++ b/frontend/frontend/src/pages/auth/Signup.jsx
@@ -63,24 +63,6 @@ export default function Signup() {
             </div>
           </div>
 
-          <div className="form-group">
-            <div className="input-wrapper">
-              <select
-                id="role"
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
-                required
-              >
-                <option value="customer">Customer</option>
-                <option value="analyst">Loan Officer / Analyst</option>
-                <option value="regulator">Regulator / Compliance Officer</option>
-                <option value="admin">Data Scientist / Admin</option>
-              </select>
-              <label htmlFor="role">Select Role</label>
-              <span className="focus-border"></span>
-            </div>
-          </div>
-
           <button type="submit" className="login-btn btn">
             <span className="btn-text">Sign Up</span>
             <span className="btn-loader"></span>


### PR DESCRIPTION
**Description**
- RoleEnum added (customer, analyst, regulator, admin)
- User.role now a strict SQLAlchemy Enum with default 'customer'
- Registration ignores role input; all new users are 'customer'
- Admin role assignment endpoint stub (/auth/admin/assign-role)

Closes #<15>