### PR TITLE
Consolidate DB schema: single Base with startup create_all() and registered core/auth models

### DIFF
--- a/backend/src/core/models.py
+++ b/backend/src/core/models.py
@@ -1,11 +1,9 @@
 # backend/src/core/models.py
-import os
 from sqlalchemy import (
     Column, Integer, String, Float, Numeric, ForeignKey, TIMESTAMP, Text
 )
 from sqlalchemy.orm import relationship
-from ..db import Base, engine
-
+from ..db import Base
 
 # Core Domain Models Only
 
@@ -92,11 +90,3 @@ class ExplanationResults(Base):
     summary = Column(Text, nullable=True)
 
     model_result = relationship("ModelResults", back_populates="explanations")
-
-
-# Create Tables if Run Directly
-
-if __name__ == "__main__":
-    Base.metadata.create_all(bind=engine)
-    print("✅ Core DB schema created at",
-          os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "IS_PROJECT_II_backend.db")))

--- a/backend/src/db.py
+++ b/backend/src/db.py
@@ -4,9 +4,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-DB_PATH = os.path.join(BASE_DIR, "IS_PROJECT_II_backend.db")
-DATABASE_URL = f"sqlite:///{DB_PATH}"
+DATA_DIR = os.path.join(BASE_DIR, "data")
+os.makedirs(DATA_DIR, exist_ok=True)
 
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+DB_PATH = os.path.join(DATA_DIR, "IS_PROJECT_II_backend.db")
+SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,13 +1,15 @@
 # backend/src/main.py
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import inspect
+
 from .db import engine, Base
+from .auth import routes as auth_routes
 from .auth import rbac_routes as rbac_routes
 
-# import models so all tables register
+# Import models so all tables are registered with Base BEFORE create_all()
 from .auth import models as auth_models
 from .core import models as core_models
-from .auth import routes as auth_routes
 
 app = FastAPI(title="Backend API")
 
@@ -24,11 +26,9 @@ app.add_middleware(
 app.include_router(auth_routes.router)
 app.include_router(rbac_routes.router)
 
-# Create DB tables at startup
-Base.metadata.create_all(bind=engine)
-
-if __name__ == "__main__":
+# Create DB tables once on startup (prevents duplication & ensures all models are registered)
+@app.on_event("startup")
+def on_startup():
     Base.metadata.create_all(bind=engine)
-    import os
-    from .db import DB_PATH
-    print(f"✅ Database created successfully at: {DB_PATH}")
+    insp = inspect(engine)
+    print("✅ Tables registered:", insp.get_table_names())

--- a/frontend/frontend/src/styles/login.css
+++ b/frontend/frontend/src/styles/login.css
@@ -88,9 +88,6 @@
   background: rgba(102,126,234,0.06);
 }
 
-/* ===== Form ===== */
-.auth-form {}
-
 /* Group + floating labels */
 .form-group {
   margin-bottom: 20px;


### PR DESCRIPTION
**Description**

- Keeps domain schema (Customer, CreditAccount, Payment, ModelResults, Explanations)
- Removes inline create_all() from core/models
- Moves create_all() to FastAPI startup event in main.py
- Ensures models are imported before metadata creation
- Prints table list at startup for quick verification

This stabilizes DB setup and avoids duplicate or missing table issues.

closes <#17>